### PR TITLE
Gatling v3.15.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+.claude/
+AGENTS.md

--- a/3.15.1/Dockerfile
+++ b/3.15.1/Dockerfile
@@ -1,0 +1,39 @@
+# Gatling is a highly capable load testing tool.
+#
+# Documentation: https://gatling.io/docs/3.2/
+# Cheat sheet: https://gatling.io/docs/3.2/cheat-sheet/
+
+FROM amazoncorretto:26-alpine3.21-jdk
+
+MAINTAINER Nadezhda Ryabtsova <nadezhdaryabtsova@gmail.com>
+
+# gating version
+ENV GATLING_VERSION 3.15.1
+
+# working directory for gatling
+WORKDIR /opt/
+
+# install gatling
+RUN mkdir -p gatling && \
+    apk upgrade --update-cache --available && \
+    apk add --update wget bash libc6-compat && \
+    mkdir -p /tmp/downloads && \
+    wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
+    https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
+    mkdir -p /tmp/archive && cd /tmp/archive && \
+    unzip /tmp/downloads/gatling-$GATLING_VERSION.zip && \
+    mv /tmp/archive/gatling-charts-highcharts-bundle-$GATLING_VERSION/* /opt/gatling/ && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/apk/*
+
+# change context to gatling directory
+WORKDIR  /opt/gatling
+
+# set directories below to be mountable from host
+VOLUME ["/opt/gatling/conf", "/opt/gatling/results", "/opt/gatling/user-files"]
+
+# set environment variables
+ENV PATH /opt/gatling/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV GATLING_HOME /opt/gatling
+
+ENTRYPOINT ["gatling.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-./3.15.0/Dockerfile
+./3.15.1/Dockerfile

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Docker image for [Gatling](https://gatling.io/) load testing tool
 
 ## Supported tags and respective `Dockerfile` links
 
-* [`latest`](https://github.com/ladamalina/gatling/blob/master/3.15.0/Dockerfile)
-* [`3.15.0`](https://github.com/ladamalina/gatling/blob/master/3.15.0/Dockerfile)
+* [`latest`](https://github.com/ladamalina/gatling/blob/master/3.15.1/Dockerfile)
+* [`3.15.1`](https://github.com/ladamalina/gatling/blob/master/3.15.1/Dockerfile), [`3.15.0`](https://github.com/ladamalina/gatling/blob/master/3.15.0/Dockerfile)
 * [`3.14.9`](https://github.com/ladamalina/gatling/blob/master/3.14.9/Dockerfile), [`3.14.8`](https://github.com/ladamalina/gatling/blob/master/3.14.8/Dockerfile), [`3.14.7`](https://github.com/ladamalina/gatling/blob/master/3.14.7/Dockerfile), [`3.14.6`](https://github.com/ladamalina/gatling/blob/master/3.14.6/Dockerfile), [`3.14.5`](https://github.com/ladamalina/gatling/blob/master/3.14.5/Dockerfile), [`3.14.4`](https://github.com/ladamalina/gatling/blob/master/3.14.4/Dockerfile), [`3.14.3`](https://github.com/ladamalina/gatling/blob/master/3.14.3/Dockerfile), [`3.14.2`](https://github.com/ladamalina/gatling/blob/master/3.14.2/Dockerfile), [`3.14.1`](https://github.com/ladamalina/gatling/blob/master/3.14.1/Dockerfile), [`3.14.0`](https://github.com/ladamalina/gatling/blob/master/3.14.0/Dockerfile)
 * [`3.13.5`](https://github.com/ladamalina/gatling/blob/master/3.13.5/Dockerfile), [`3.13.4`](https://github.com/ladamalina/gatling/blob/master/3.13.4/Dockerfile), [`3.13.3`](https://github.com/ladamalina/gatling/blob/master/3.13.3/Dockerfile), [`3.13.1`](https://github.com/ladamalina/gatling/blob/master/3.13.1/Dockerfile)
 * [`3.12.0`](https://github.com/ladamalina/gatling/blob/master/3.12.0/Dockerfile)
@@ -33,7 +33,7 @@ docker pull ladamalina/gatling:latest
 docker pull ladamalina/gatling
 
 # Specific version:
-docker pull ladamalina/gatling:3.15.0
+docker pull ladamalina/gatling:3.15.1
 ```
 
 * [Alternatively] Build an image from Dockerfile:


### PR DESCRIPTION
Add support for Gatling 3.15.1

- New version directory with updated base image (amazoncorretto:26-alpine3.21-jdk)
- Updated root Dockerfile symlink
- Updated README with new tags